### PR TITLE
feat: add lookup sha based on action

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,33 @@ curl -sf https://raw.githubusercontent.com/cybrota/scharf/refs/heads/main/instal
 ```
 
 ## Getting Started
-Scharf comes with one simple command to scan all Git repositories(branches, tags) stored in a workspace directory.
+Scharf comes with two simple commands:
+1. find
+2. lookup
 
-Clone all your organization GitHub repositories to a directory and point it to --root.
+Clone all your organization GitHub repositories to a directory (Ex: workspace).
+
+1. Find all actions (branches, tags) with mutable third-party action refereces.
 
 ```sh
-scharf run --root=/path/to/workspace --out=json
+scharf find --root=/path/to/workspace --out=json
 ```
 
 To export results to CSV for analysis:
 
 ```sh
-scharf run --root=/path/to/workspace --out=csv
+scharf find --root /path/to/workspace --out csv
 ```
+
+2. Quickly lookup SHA for a given public, third-party GitHub action.
+```sh
+scharf lookup actions/checkout@v4 // 11bd71901bbe5b1630ceea73d27597364c9af683
+
+scharf lookup actions/setup-java@main // 3b6c050358614dd082e53cdbc55580431fc4e437
+
+scharf lookup hashicorp/setup-terraform // 852ca175a624bfb8d1f41b0dbcf92b3556fbc25f, pins main branch as default
+```
+
 
 ## Why Scharf?
 
@@ -72,9 +86,6 @@ Use Scharf to pro-actively avoid supply chain attacks which can exfiltrate sensi
 
 ## Key Features of Scharf
 
-* **Repository Discovery**: Automatically scan all repositories in a given GitHub organization.
 * **Workflow Analysis**: Parse GitHub CI/CD workflows to identify usage of third-party actions.
-* **Security Flags**: Detect and flag actions that reference versions via tags or branches instead of immutable SHA commits.
-* **Customizable Scanning**: Specify organization and project filters to fine-tune your security audits.
 * **Actionable Reports**: Generates detailed CSv & JSON reports that help you quickly identify and remediate insecure references.
-* **Easy Integration**: Integrate Scharf into your CI/CD pipelines for continuous security validation of workflow files.
+* **Easy SHA Lookup**: Fetch up-to-date SHA of a GitHub action to fix workflows found with mutable references.

--- a/main.go
+++ b/main.go
@@ -55,8 +55,8 @@ func WriteToCSV(inv *Inventory) {
 
 func main() {
 
-	var cmdRun = &cobra.Command{
-		Use:   "run",
+	var cmdFind = &cobra.Command{
+		Use:   "find",
 		Short: "Launches scharf with provided options for workspace root and output format",
 		Long:  fmt.Sprintf("%s\n%s", asciiLogo, `Launches scharf with provided options for workspace root and output format`),
 		Args:  cobra.MinimumNArgs(0),
@@ -92,10 +92,30 @@ func main() {
 		},
 	}
 
-	cmdRun.PersistentFlags().String("root", ".", "Absolute path of root directory of GitHub repositories")
-	cmdRun.PersistentFlags().String("out", "json", "Output format of findings. Available options: json, csv")
+	var cmdLookup = &cobra.Command{
+		Use:   "lookup",
+		Short: "Look up the immutable commit-SHA of a given action & version string. Ex: actions/checkout@v4",
+		Long:  fmt.Sprintf("%s\n%s", asciiLogo, `Look up the immutable commit-SHA of a given action & version string. Ex: actions/checkout@v4`),
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if args[0] != "" {
+				s := SHAResolver{}
+				sha, err := s.resolve(args[0])
+				if err != nil {
+					slog.Error("problem while fetching action SHA:", "error", err.Error())
+				}
+
+				fmt.Println(sha)
+			} else {
+				slog.Error("Please give a GitHub action to look up SHA-commit. Ex: actions/checkout@v4")
+			}
+		},
+	}
+
+	cmdFind.PersistentFlags().String("root", ".", "Absolute path of root directory of GitHub repositories")
+	cmdFind.PersistentFlags().String("out", "json", "Output format of findings. Available options: json, csv")
 
 	var rootCmd = &cobra.Command{Use: "scharf", Long: asciiLogo}
-	rootCmd.AddCommand(cmdRun)
+	rootCmd.AddCommand(cmdLookup, cmdFind)
 	rootCmd.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func main() {
 				s := SHAResolver{}
 				sha, err := s.resolve(args[0])
 				if err != nil {
-					slog.Error("problem while fetching action SHA:", "error", err.Error())
+					slog.Error("problem while fetching action SHA. Please check the action again.", "action", args[0])
 				}
 
 				fmt.Println(sha)

--- a/resolver.go
+++ b/resolver.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+const apiURL = "https://api.github.com/repos"
+
+// Resolver is a converter for action@version to a SHA string
+type Resolver interface {
+	// resolve checks if SHA is available for a given version of GitHub action
+	resolve(action string) (string, error)
+}
+
+// searchTag probes for a given version tag in list of tags and returns SHA commit
+func searchTag(tags []BranchOrTag, version string) (bool, string) {
+	for _, t := range tags {
+		if t.Name == version {
+			if t.Commit.Sha == "" {
+				return false, ""
+			} else {
+				return true, t.Commit.Sha
+			}
+		}
+		continue
+	}
+
+	return false, ""
+}
+
+// splitRawAction takes a raw action reference and splits it as action & version
+func splitRawAction(raw string) [2]string {
+	splits := strings.Split(raw, "@")
+
+	if len(splits) == 2 {
+		return [2]string{
+			splits[0],
+			splits[1],
+		}
+	} else if len(splits) == 1 {
+		return [2]string{
+			splits[0],
+			"",
+		}
+	}
+
+	return [2]string{}
+}
+
+// makeAPIEndpoint checks if  agiven version is a branch or tag and builds endpoint
+func makeAPIEndpoint(action string, version string) string {
+	var lookupURL string
+
+	if strings.HasPrefix(strings.ToLower(version), "v") {
+		lookupURL = fmt.Sprintf("%s/%s/tags", apiURL, action)
+	} else {
+		lookupURL = fmt.Sprintf("%s/%s/branches", apiURL, action)
+	}
+
+	return lookupURL
+}
+
+// SHAResolver resolves a given action to it's safe SHA commit
+type SHAResolver struct{}
+
+type Commit struct {
+	Sha string `json:"sha"`
+	URL string `json:"url"`
+}
+
+type BranchOrTag struct {
+	Name   string `json:"name"`
+	Commit Commit `json:"commit"`
+}
+
+// resolve fetches list of tags for a given GitHub action and picks SHA commit
+func (s SHAResolver) resolve(action string) (string, error) {
+	splits := splitRawAction(action)
+	actionBase := splits[0]
+	version := splits[1]
+
+	if version == "" {
+		version = "main"
+	}
+
+	url := makeAPIEndpoint(actionBase, version)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("http: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var b []BranchOrTag
+	if err := json.NewDecoder(resp.Body).Decode(&b); err != nil {
+		return "", fmt.Errorf("json: %w", err)
+	}
+
+	found, sha := searchTag(b, version)
+	if !found {
+		return "", errors.New(fmt.Sprintf("given version: %s is not found for action: %s", version, actionBase))
+	}
+
+	return sha, nil
+}

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -1,0 +1,311 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+)
+
+// --- Helper functions for testing ---
+
+// roundTripFunc type is an adapter to allow the use of
+// ordinary functions as http.RoundTripper.
+type roundTripFunc func(req *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+// withHTTPClientTransport temporarily replaces the default transport.
+func withHTTPClientTransport(rt http.RoundTripper, fn func()) {
+	orig := http.DefaultClient.Transport
+	http.DefaultClient.Transport = rt
+	defer func() { http.DefaultClient.Transport = orig }()
+	fn()
+}
+
+// --- Tests for splitRawAction ---
+
+func TestSplitRawAction(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected [2]string
+	}{
+		{
+			name:     "action with version",
+			input:    "owner/repo@v1.0.0",
+			expected: [2]string{"owner/repo", "v1.0.0"},
+		},
+		{
+			name:     "action without version",
+			input:    "owner/repo",
+			expected: [2]string{"owner/repo", ""},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: [2]string{"", ""},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := splitRawAction(tc.input)
+			if got != tc.expected {
+				t.Errorf("splitRawAction(%q) = %v; want %v", tc.input, got, tc.expected)
+			}
+		})
+	}
+}
+
+// --- Tests for makeAPIEndpoint ---
+
+func TestMakeAPIEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		action   string
+		version  string
+		expected string
+	}{
+		{
+			name:     "version starts with v (tag)",
+			action:   "owner/repo",
+			version:  "v1.0.0",
+			expected: "https://api.github.com/repos/owner/repo/tags",
+		},
+		{
+			name:     "version does not start with v (branch)",
+			action:   "owner/repo",
+			version:  "main",
+			expected: "https://api.github.com/repos/owner/repo/branches",
+		},
+		{
+			name:     "version lowercase check",
+			action:   "owner/repo",
+			version:  "V2.0.0", // Even if uppercase, we lowercase the prefix
+			expected: "https://api.github.com/repos/owner/repo/tags",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := makeAPIEndpoint(tc.action, tc.version)
+			if got != tc.expected {
+				t.Errorf("makeAPIEndpoint(%q, %q) = %v; want %v", tc.action, tc.version, got, tc.expected)
+			}
+		})
+	}
+}
+
+// --- Tests for searchTag ---
+
+func TestSearchTag(t *testing.T) {
+	tags := []BranchOrTag{
+		{
+			Name: "v1.0.0",
+			Commit: Commit{
+				Sha: "sha-1",
+			},
+		},
+		{
+			Name: "main",
+			Commit: Commit{
+				Sha: "sha-main",
+			},
+		},
+		{
+			Name: "v2.0.0",
+			Commit: Commit{
+				Sha: "",
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		version       string
+		expectedFound bool
+		expectedSHA   string
+	}{
+		{
+			name:          "found valid tag",
+			version:       "v1.0.0",
+			expectedFound: true,
+			expectedSHA:   "sha-1",
+		},
+		{
+			name:          "found branch",
+			version:       "main",
+			expectedFound: true,
+			expectedSHA:   "sha-main",
+		},
+		{
+			name:          "tag exists but empty sha",
+			version:       "v2.0.0",
+			expectedFound: false,
+			expectedSHA:   "",
+		},
+		{
+			name:          "non-existing version",
+			version:       "v3.0.0",
+			expectedFound: false,
+			expectedSHA:   "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			found, sha := searchTag(tags, tc.version)
+			if found != tc.expectedFound || sha != tc.expectedSHA {
+				t.Errorf("searchTag(tags, %q) = (%v, %q); want (%v, %q)", tc.version, found, sha, tc.expectedFound, tc.expectedSHA)
+			}
+		})
+	}
+}
+
+// --- Tests for SHAResolver.resolve ---
+// We simulate the HTTP response by intercepting http.Get using a custom RoundTripper.
+func TestSHAResolver_resolve(t *testing.T) {
+	// Prepare a fake list of tags/branches response.
+	// For this test we simulate both a valid SHA and a not-found scenario.
+	responses := map[string][]BranchOrTag{
+		// When version is v1.0.0, return valid tag list.
+		"https://api.github.com/repos/owner/repo/tags": {
+			{
+				Name: "v1.0.0",
+				Commit: Commit{
+					Sha: "sha-valid",
+				},
+			},
+		},
+		// When version is main (or any branch), return branch list.
+		"https://api.github.com/repos/owner/repo/branches": {
+			{
+				Name: "main",
+				Commit: Commit{
+					Sha: "sha-main",
+				},
+			},
+		},
+		// When version is not found.
+		"https://api.github.com/repos/owner/repo/tags-notfound": {},
+	}
+
+	// customTransport intercepts HTTP requests and returns a fake response.
+	customTransport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		// Use the request URL to determine which fake response to return.
+		url := req.URL.String()
+		// For test of not found case, we simulate a valid empty list.
+		var data []BranchOrTag
+		if url == "https://api.github.com/repos/owner/repo/tags" {
+			data = responses["https://api.github.com/repos/owner/repo/tags"]
+		} else if url == "https://api.github.com/repos/owner/repo/branches" {
+			data = responses["https://api.github.com/repos/owner/repo/branches"]
+		} else {
+			data = responses["https://api.github.com/repos/owner/repo/tags-notfound"]
+		}
+
+		b, err := json.Marshal(data)
+		if err != nil {
+			return nil, err
+		}
+
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(b)),
+			Header:     make(http.Header),
+		}
+		return resp, nil
+	})
+
+	// Override the HTTP transport for the duration of these tests.
+	withHTTPClientTransport(customTransport, func() {
+		tests := []struct {
+			name        string
+			inputAction string
+			expectedSHA string
+			expectError bool
+		}{
+			{
+				name:        "valid tag resolution",
+				inputAction: "owner/repo@v1.0.0",
+				expectedSHA: "sha-valid",
+				expectError: false,
+			},
+			{
+				name:        "empty version defaults to main branch",
+				inputAction: "owner/repo",
+				// When no version is provided, resolve() sets it to "main"
+				expectedSHA: "sha-main",
+				expectError: false,
+			},
+			{
+				name:        "version not found",
+				inputAction: "owner/repo@nonexistent",
+				expectError: true,
+			},
+		}
+
+		resolver := SHAResolver{}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				sha, err := resolver.resolve(tc.inputAction)
+				if tc.expectError {
+					if err == nil {
+						t.Errorf("Expected error for input %q, got nil", tc.inputAction)
+					}
+				} else {
+					if err != nil {
+						t.Errorf("Unexpected error for input %q: %v", tc.inputAction, err)
+					}
+					if sha != tc.expectedSHA {
+						t.Errorf("resolve(%q) returned sha %q; want %q", tc.inputAction, sha, tc.expectedSHA)
+					}
+				}
+			})
+		}
+	})
+}
+
+// --- Test for handling HTTP errors in resolve ---
+func TestSHAResolver_resolve_HTTPError(t *testing.T) {
+	// Create a custom transport that simulates an HTTP error.
+	customTransport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("simulated http error")
+	})
+
+	withHTTPClientTransport(customTransport, func() {
+		resolver := SHAResolver{}
+		_, err := resolver.resolve("owner/repo@v1.0.0")
+		if err == nil {
+			t.Errorf("Expected error when HTTP GET fails, got nil")
+		}
+	})
+}
+
+// --- Test for handling invalid JSON in resolve ---
+func TestSHAResolver_resolve_InvalidJSON(t *testing.T) {
+	// Create a custom transport that returns invalid JSON.
+	customTransport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		b := []byte("invalid json")
+		resp := &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(b)),
+			Header:     make(http.Header),
+		}
+		return resp, nil
+	})
+
+	withHTTPClientTransport(customTransport, func() {
+		resolver := SHAResolver{}
+		_, err := resolver.resolve("owner/repo@v1.0.0")
+		if err == nil {
+			t.Errorf("Expected error when JSON decoding fails, got nil")
+		}
+	})
+}

--- a/scanner.go
+++ b/scanner.go
@@ -25,7 +25,7 @@ func (s *Scanner) ScanRepos(root string, dirPath string, regex *regexp.Regexp) (
 	var inventory Inventory
 	absolutePath, err := filepath.Abs(root)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("filepath: %w", err)
 	}
 
 	// Retrieve repositories from the VCS.
@@ -106,7 +106,7 @@ func (g GitHubVCS) ListRepositories(root string) ([]Repository, error) {
 
 	if err != nil {
 		logger.Error("failed to read root directory", "err", err)
-		return nil, err
+		return nil, fmt.Errorf("os: %w", err)
 	}
 
 	var rs []Repository
@@ -143,7 +143,7 @@ func (g GitRepository) ListBranches() ([]string, error) {
 func (g GitRepository) ListFiles(loc string) ([]string, error) {
 	entries, err := os.ReadDir(loc)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("os: %w", err)
 	}
 
 	var files []string
@@ -157,7 +157,7 @@ func (g GitRepository) ListFiles(loc string) ([]string, error) {
 func (g GitRepository) ReadFile(filePath string) ([]byte, error) {
 	content, err := os.ReadFile(filePath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("os: %w", err)
 	}
 
 	return content, nil


### PR DESCRIPTION
## Description 

- Changes API from `run` to `find`
- Add a new command `lookup` for looking up SHA of a action.

```sh
scharf lookup actions/checkout@v4 //  11bd71901bbe5b1630ceea73d27597364c9af683
```