### PR TITLE
feat/2: Add Audit command to check mutable actions in current Git repository

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// AuditRepository collects inventory details from current Git repository.
+func AuditRepository(regex *regexp.Regexp) (*Inventory, error) {
+
+	if !IsGitRepo(".") {
+		return nil, fmt.Errorf("The current directory is not a Git repository")
+	}
+
+	var inventory Inventory
+	absPath, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("dir error: %w", err)
+	}
+
+	paths := strings.Split(absPath, "/")
+	repo := &GitRepository{
+		localPath: absPath,
+		name:      paths[len(paths)-1],
+	}
+	workflowPath := fmt.Sprintf("%s/.github/workflows", absPath)
+
+	fileNames, err := repo.ListFiles(workflowPath)
+	if err != nil {
+		return nil, fmt.Errorf("file error: %w", err)
+	}
+
+	// Process each file found in the directory.
+	for _, fileName := range fileNames {
+		fPath := fmt.Sprintf("%s/%s", workflowPath, fileName)
+		content, err := repo.ReadFile(fPath)
+		if err != nil {
+			return nil, fmt.Errorf("file error: %w", err)
+		}
+
+		found := regex.FindAll([]byte(content), -1)
+		var matches []string
+		for _, match := range found {
+			matches = append(matches, string(match))
+		}
+
+		b, err := GetCurrentBranch(absPath)
+		if err != nil {
+			return nil, fmt.Errorf("git error: %w", err)
+		}
+
+		if len(matches) > 0 {
+			inventory.Records = append(inventory.Records, &InventoryRecord{
+				Repository: repo.Name(),
+				Branch:     b,
+				FilePath:   fPath,
+				Matches:    matches,
+			})
+		}
+	}
+
+	return &inventory, nil
+}

--- a/git.go
+++ b/git.go
@@ -60,3 +60,28 @@ func CheckoutGitBranch(repoPath, branchName string) error {
 
 	return nil
 }
+
+// GetCurrentBranch returns the head ref of a Git Repository
+func GetCurrentBranch(path string) (string, error) {
+	repo, err := git.PlainOpen(path)
+	if err != nil {
+		return "", err
+	}
+
+	head, err := repo.Head()
+	if err != nil {
+		return "", err
+	}
+
+	return head.Name().String(), nil
+}
+
+// IsGitRepo detects if a given repository is Git initialized
+func IsGitRepo(path string) bool {
+	_, err := git.PlainOpen(path)
+	if err != nil {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
## Description

This PR adds a new command called `audit` to list all matching actions with mutable references.

With a flag: `--raise-error`, one can issue Exit Code ` for CI systems to break on detection.

```sh
scharf audit --raise-error
```

Output:

```sh
No mutable references found. Good job!
```

or

```sh
Mutable references found in your GitHub actions. Please replace them to secure your CI from supply chain attacks.
+---------------------+-------------------------------------------------------+------------------------------------------+
|        MATCH        |                       FILEPATH                        |             REPLACE WITH SHA             |
+---------------------+-------------------------------------------------------+------------------------------------------+
| actions/checkout@v4 | /Users/narenyellavula/scharf/.github/workflows/ci.yml | 11bd71901bbe5b1630ceea73d27597364c9af683 |
+---------------------+-------------------------------------------------------+------------------------------------------+
```

based on matches found.