### PR TITLE
feat/10: add --head-only option to find command to limit scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Scharf is a CLI tool to detect third-party GitHub actions with mutable reference
 
 Scharf helps you maintain a secure development lifecycle by ensuring that all third-party actions are pinned to a specific commit SHA. This approach minimizes risks associated with dependency drifting and unintentional code modifications.
 
+## Key Features of Scharf
+
+* **Workflow Analysis**: Parse GitHub CI/CD workflows to identify usage of third-party actions.
+* **Actionable Reports**: Generates detailed  JSON & CSV reports to help you quickly identify and remediate insecure references.
+* **Easy SHA Lookup**: Fetch up-to-date SHA of a GitHub action to fix workflows found with mutable references.
+
 ## Installation
 
 Install Scharf binary easily on Linux or Mac OS:
@@ -40,6 +46,10 @@ Scharf comes with two types of commands to assist hardening of GitHub third-part
 
 1. Discovery Commands (audit, find)
 2. Remediation Commands(lookup, list)
+
+<hr />
+
+## Discovery Commands
 
 ### Audit: Quickly check if your Git repository has any mutable references using `audit` command. This is useful for single repository
 Ex:
@@ -57,19 +67,28 @@ Mutable references found in your GitHub actions. Please replace them to secure y
 +---------------------+-------------------------------------------------------+------------------------------------------+
 ```
 
-### Find:  Audit across multiple Git repositories and export matches to a file. For example, clone all your organization GitHub repositories to a directory (Ex: workspace), and run:
-This operation includes all branches in GitHub repositories.
-Ex:
+### Find:  Scan across multiple Git repositories and export results to a file. For example, clone all your organization GitHub repositories to a directory (Ex: workspace), and run:
+
+This operation can include all branches in GitHub repositories (default). All branches excludes tags.
+
+Ex Scan all branches:
 ```sh
-scharf find --root=/path/to/workspace --out=json
+scharf find --root=/path/to/workspace
 ```
 
-To export results to CSV for analysis:
+This exports results to JSON. To export results to CSV, pass `--out csv` flag:
 
 ```sh
 scharf find --root /path/to/workspace --out csv
 ```
 
+Ex Only scan currently set HEAD in workspace repositories
+```sh
+scharf find --root=/path/to/workspace --head-only
+```
+<hr />
+
+## Remediation Commands
 ### Lookup: Qickly lookup SHA for a third-party GitHub action. Must include version
 Ex:
 ```sh
@@ -143,7 +162,7 @@ jobs:
         with:
           raise-error: true
 ```
-
+<hr />
 ## Why mutable tags in GitHub CI/CD workflows are bad ?
 
 Using mutable references like tag-based or branch-based references in your CI/CD workflows can lead to unexpected changes or potential security vulnerabilities if the referenced action is compromised by malicious actors.
@@ -160,12 +179,3 @@ Scharf lets you identify and mitigate against supply-chain attacks similar to "t
 * https://alexwlchan.net/2025/github-actions-audit/
 
 * https://github.com/advisories/ghsa-mrrh-fwg8-r2c3
-
-
-Use Scharf to pro-actively avoid supply chain attacks which can exfiltrate sensitive data from CI/CD workflows and cause reputation damage.
-
-## Key Features of Scharf
-
-* **Workflow Analysis**: Parse GitHub CI/CD workflows to identify usage of third-party actions.
-* **Actionable Reports**: Generates detailed CSv & JSON reports that help you quickly identify and remediate insecure references.
-* **Easy SHA Lookup**: Fetch up-to-date SHA of a GitHub action to fix workflows found with mutable references.

--- a/git.go
+++ b/git.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 )
 
+// ListTags lists all tags available for a given repository
 func ListTags(repo *git.Repository) ([]string, error) {
 	var tags []string
 	tagIter, err := repo.Tags()

--- a/git.go
+++ b/git.go
@@ -2,10 +2,26 @@ package main
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 )
+
+func ListTags(repo *git.Repository) ([]string, error) {
+	var tags []string
+	tagIter, err := repo.Tags()
+
+	if err != nil {
+		return nil, fmt.Errorf("git error: %w", err)
+	}
+	tagIter.ForEach(func(ref *plumbing.Reference) error {
+		tags = append(tags, ref.Name().Short())
+		return nil
+	})
+
+	return tags, nil
+}
 
 // ListGitBranches opens the Git repository located at repoPath
 // and returns a slice of branch names found in the repository.
@@ -23,9 +39,16 @@ func ListGitBranches(repoPath string) ([]string, error) {
 	}
 
 	var branchNames []string
+	tags, err := ListTags(repo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve tags: %w", err)
+	}
+
 	// Iterate over each branch reference and add the short name to our list
 	err = branches.ForEach(func(ref *plumbing.Reference) error {
-		branchNames = append(branchNames, ref.Name().Short())
+		if !slices.Contains(tags, ref.Name().Short()) {
+			branchNames = append(branchNames, ref.Name().Short())
+		}
 		return nil
 	})
 	if err != nil {

--- a/interfaces.go
+++ b/interfaces.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+)
+
+// Scanner ties together VCS operations with file scanning logic.
+type Scanner struct {
+	// VCS system implementation (e.g., GitHub, GitLab)
+	VCS         VCS
+	FileScanner FileScanner
+}
+
+func (s *Scanner) ScanBranch(branch string, repo Repository, regex *regexp.Regexp, dirPath string) *InventoryRecord {
+	fileNames, err := repo.ListFiles(dirPath)
+	if err != nil {
+		// The directory might not exist on this branch; skip to next branch.
+		logger.Debug("directory might not exist on branch. skipping to next repo")
+		return nil
+	}
+
+	// Process each file found in the directory.
+	for _, fileName := range fileNames {
+		fPath := fmt.Sprintf("%s/%s", dirPath, fileName)
+		content, err := repo.ReadFile(fPath)
+		if err != nil {
+			// Log error and skip this file.
+			logger.Debug("workflow directory might not exist. skipping to next repo")
+			continue
+		}
+
+		matches, err := s.FileScanner.ScanContent(content, regex)
+		if err != nil {
+			// Log error and skip this file.
+			continue
+		}
+
+		if len(matches) > 0 {
+			return &InventoryRecord{
+				Repository: repo.Name(),
+				Branch:     branch,
+				FilePath:   fPath,
+				Matches:    matches,
+			}
+		}
+	}
+	return nil
+}
+
+// ScanRepos traverses all repositories found under the root directory,
+// checks each branch, enumerates over files in the given workflow directory path,
+// and scans each file's content for regex matches.
+// ho - HEAD only
+func (s *Scanner) ScanRepos(root string, regex *regexp.Regexp, ho bool) (*Inventory, error) {
+	var inventory Inventory
+	absolutePath, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("filepath: %w", err)
+	}
+
+	// Retrieve repositories from the VCS.
+	repos, err := s.VCS.ListRepositories(absolutePath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Process each repository.
+	for _, repo := range repos {
+		branches, err := repo.ListBranches()
+		if err != nil {
+			// Log error and continue with next repository.
+			logger.Debug("couldn't detect branches. skipping to next repo")
+			continue
+		}
+
+		if ho {
+			branches = []string{"HEAD"}
+		}
+
+		// For each branch, enumerate files in the specified directory.
+		for _, branch := range branches {
+			searchPath := fmt.Sprintf("%s/%s/.github/workflows", absolutePath, repo.Name())
+			logger.Debug("Processing the repo:", "repo", repo.Name(), "branch", branch, "filepath", searchPath)
+			ir := s.ScanBranch(branch, repo, regex, searchPath)
+			if ir != nil {
+				inventory.Records = append(inventory.Records, ir)
+			}
+		}
+	}
+
+	return &inventory, nil
+}
+
+// Repository abstracts a single repository and its operations.
+type Repository interface {
+	Name() string
+
+	// Location gets absolute path of repository
+	Location() string
+	// ListBranches returns all branches available in the repository.
+	ListBranches() ([]string, error)
+	// ReadFile retrieves the content of a file given a file path.
+	ReadFile(filePath string) ([]byte, error)
+	// ListFiles returns all file paths under a given directory in a branch.
+	ListFiles(loc string) ([]string, error)
+	// SwitchBranch checks out the repository to given branch
+	SwitchBranch(branchName string) error
+}
+
+// Branch abstracts a branch in a repository.
+type Branch interface {
+	Name() string
+}
+
+// FileScanner defines functionality to scan file content using a regex.
+type FileScanner interface {
+	ScanContent(content []byte, regex *regexp.Regexp) ([]string, error)
+}
+
+// VCS defines operations common to all version control systems.
+type VCS interface {
+	ListRepositories(root string) ([]Repository, error)
+}

--- a/logging.go
+++ b/logging.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+)
+
+func getLogger(lvl slog.Level) *slog.Logger {
+	// Global logger instance.
+	if lvl == 0 {
+		lvl = slog.LevelInfo
+	}
+	h := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: lvl})
+	slog.SetDefault(slog.New(h))
+	logger := slog.Default()
+	return logger
+}
+
+var logger = getLogger(0)

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ _______ _______ _     _ _______  ______ _______
 |______ |       |_____| |_____| |_____/ |______
 ______| |_____  |     | |     | |    \_ |
 
-Copyright @ Cybrota (https://github.com/cybrota)
+Software Copyright @ Cybrota (https://github.com/cybrota)
 `
 
 func writeToJSON(inv *Inventory) {
@@ -72,10 +72,17 @@ func main() {
 			}
 
 			root_path_flag := cmd.Flag("root")
+			var ho bool
+			head_only := cmd.Flag("head-only")
+			if head_only.Value.String() == "true" {
+				ho = true
+			} else {
+				ho = false
+			}
 
 			// Regex to find whether workflow has reference to vXY, main, dev or master
 			regex, _ := regexp.Compile(`(\w*-?\w*)(\/)(\w+-?\w+)@((v\w+)|main|dev|master)`)
-			inv, err := sc.ScanRepos(root_path_flag.Value.String(), ".github/workflows", regex)
+			inv, err := sc.ScanRepos(root_path_flag.Value.String(), regex, ho)
 
 			if err != nil {
 				log.Fatal(err.Error())
@@ -118,6 +125,7 @@ func main() {
 	}
 	cmdFind.PersistentFlags().String("root", ".", "Absolute path of root directory of GitHub repositories")
 	cmdFind.PersistentFlags().String("out", "json", "Output format of findings. Available options: json, csv")
+	cmdFind.PersistentFlags().Bool("head-only", false, "Limit scan only to HEAD (Activated branch)")
 
 	var cmdList = &cobra.Command{
 		Use:   "list",

--- a/scanner.go
+++ b/scanner.go
@@ -2,85 +2,9 @@ package main
 
 import (
 	"fmt"
-	"log/slog"
 	"os"
-	"path/filepath"
 	"regexp"
 )
-
-// Global logger instance.
-var logger = slog.Default()
-
-// Scanner ties together VCS operations with file scanning logic.
-type Scanner struct {
-	// VCS system implementation (e.g., GitHub, GitLab)
-	VCS         VCS
-	FileScanner FileScanner
-}
-
-// ScanRepos traverses all repositories found under the root directory,
-// checks each branch, enumerates over files in the given workflow directory path,
-// and scans each file's content for regex matches.
-func (s *Scanner) ScanRepos(root string, dirPath string, regex *regexp.Regexp) (*Inventory, error) {
-	var inventory Inventory
-	absolutePath, err := filepath.Abs(root)
-	if err != nil {
-		return nil, fmt.Errorf("filepath: %w", err)
-	}
-
-	// Retrieve repositories from the VCS.
-	repos, err := s.VCS.ListRepositories(absolutePath)
-	if err != nil {
-		return nil, err
-	}
-
-	// Process each repository.
-	for _, repo := range repos {
-		branches, err := repo.ListBranches()
-		if err != nil {
-			// Log error and continue with next repository.
-			logger.Debug("couldn't detect branches. skipping to next repo")
-			continue
-		}
-
-		// For each branch, enumerate files in the specified directory.
-		for _, branch := range branches {
-			fileNames, err := repo.ListFiles(fmt.Sprintf("%s/%s/%s", absolutePath, repo.Name(), dirPath))
-			if err != nil {
-				// The directory might not exist on this branch; skip to next branch.
-				logger.Debug("directory might not exist on branch. skipping to next repo")
-				continue
-			}
-
-			// Process each file found in the directory.
-			for _, fileName := range fileNames {
-				fPath := fmt.Sprintf("%s/%s/%s/%s", absolutePath, repo.Name(), dirPath, fileName)
-				content, err := repo.ReadFile(fPath)
-				if err != nil {
-					// Log error and skip this file.
-					logger.Debug("workflow directory might not exist. skipping to next repo")
-					continue
-				}
-
-				matches, err := s.FileScanner.ScanContent(content, regex)
-				if err != nil {
-					// Log error and skip this file.
-					continue
-				}
-
-				if len(matches) > 0 {
-					inventory.Records = append(inventory.Records, &InventoryRecord{
-						Repository: repo.Name(),
-						Branch:     branch,
-						FilePath:   fPath,
-						Matches:    matches,
-					})
-				}
-			}
-		}
-	}
-	return &inventory, nil
-}
 
 // shouldIncludeDir returns false if the file should be ignored.
 func shouldIncludeDir(fileName string) bool {
@@ -91,11 +15,6 @@ func shouldIncludeDir(fileName string) bool {
 		".ropeproject": true,
 	}
 	return !ignoredFiles[fileName]
-}
-
-// VCS defines operations common to all version control systems.
-type VCS interface {
-	ListRepositories(root string) ([]Repository, error)
 }
 
 // GitHub VCS
@@ -165,32 +84,6 @@ func (g GitRepository) ReadFile(filePath string) ([]byte, error) {
 
 func (g GitRepository) SwitchBranch(branchName string) error {
 	return CheckoutGitBranch(g.localPath, branchName)
-}
-
-// Repository abstracts a single repository and its operations.
-type Repository interface {
-	Name() string
-
-	// Location gets absolute path of repository
-	Location() string
-	// ListBranches returns all branches available in the repository.
-	ListBranches() ([]string, error)
-	// ReadFile retrieves the content of a file given a file path.
-	ReadFile(filePath string) ([]byte, error)
-	// ListFiles returns all file paths under a given directory in a branch.
-	ListFiles(loc string) ([]string, error)
-	// SwitchBranch checks out the repository to given branch
-	SwitchBranch(branchName string) error
-}
-
-// Branch abstracts a branch in a repository.
-type Branch interface {
-	Name() string
-}
-
-// FileScanner defines functionality to scan file content using a regex.
-type FileScanner interface {
-	ScanContent(content []byte, regex *regexp.Regexp) ([]string, error)
 }
 
 // GitHubWorkFlowScanner implements Scanner interface

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -184,7 +184,7 @@ func TestScanner_ScanRepos(t *testing.T) {
 	}
 }
 
-// TestScanner_ScanRepos tests the ScanRepos method by wiring in fake VCS and repository implementations.
+// TestScanner_ScanReposDefaultBranch tests the ScanRepos but with passing --head-only flag value to true
 func TestScanner_ScanReposDefaultBranch(t *testing.T) {
 	// Use a dummy root; the function will convert it to an absolute path.
 	root := "dummyRoot"


### PR DESCRIPTION
## Description

Introduce a new CLI command flag for `scharf find`.

Flag: --head-only

Usage: This flag controls whether scan is limited to HEAD branch (actively set) to improve signal strength.