### PR TITLE
feat: Add auto-fix feature to replace tags

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,4 @@
-                    Apache License
-                Version 2.0, January 2004
-            http://www.apache.org/licenses/
+Apache License, Version 2.0
 
 Copyright (c) 2025 Naren Yellavula & Cybrota contributors
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,8 @@
-Copyright (c) 2025 Naren Yellavula
+                    Apache License
+                Version 2.0, January 2004
+            http://www.apache.org/licenses/
+
+Copyright (c) 2025 Naren Yellavula & Cybrota contributors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/LICENSE-3P
+++ b/LICENSE-3P
@@ -1,0 +1,26 @@
+Notice of Third-party (3P) Licenses
+
+------------------------------
+github.com/go-git/go-git
+
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses
+
+---------------------------------
+github.com/olekukonko/tablewriter
+
+Copyright (C) 2014 by Oleku Konko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+-----------------------------------
+github.com/spf13/cobra
+
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses

--- a/LICENSE-3P
+++ b/LICENSE-3P
@@ -1,6 +1,6 @@
 Notice of Third-party (3P) Licenses
 
-------------------------------
+---------------------------------
 github.com/go-git/go-git
 
 Apache License
@@ -18,7 +18,7 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
------------------------------------
+--------------------------------
 github.com/spf13/cobra
 
 Apache License

--- a/README.md
+++ b/README.md
@@ -33,9 +33,19 @@ Scharf helps you maintain a secure development lifecycle by ensuring that all th
 * **Actionable Reports**: Generates detailed  JSON & CSV reports to help you quickly identify and remediate insecure references.
 * **Easy SHA Lookup**: Fetch up-to-date SHA of a GitHub action to fix workflows found with mutable references.
 
+## Supported Platforms
+1. Linux
+2. Mac OSX
+
 ## Installation
 
-Install Scharf binary easily on Linux or Mac OS:
+1. Download binary for your platform from release versions:
+
+https://github.com/cybrota/scharf/releases
+
+or
+
+2. Run below shell script (Requires `Curl`):
 
 ```sh
 curl -sf https://raw.githubusercontent.com/cybrota/scharf/refs/heads/main/install.sh | sh
@@ -89,6 +99,27 @@ scharf find --root=/path/to/workspace --head-only
 <hr />
 
 ## Remediation Commands
+### Autofix: Auto-fixes vulnerable third-party GitHub actions in a GitHub repository
+
+Navigate to a GitHub repository, and run:
+
+Ex:
+```sh
+scharf autofix
+```
+
+```ascii
+🪄 Fixing add-issue-header.yml:
+  'actions/github-script@v7' -> 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7' ✅
+🪄 Fixing build.yml:
+  'actions/checkout@v4' -> 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4' ✅
+  'actions/checkout@v4' -> 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4' ✅
+  'actions/setup-python@v5' -> 'actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5' ✅
+  'actions/cache@v4' -> 'actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4' ✅
+```
+
+`Note`: This command modifies file content which can be safely committed to Git.
+
 ### Lookup: Qickly lookup SHA for a third-party GitHub action. Must include version
 Ex:
 ```sh
@@ -163,6 +194,7 @@ jobs:
           raise-error: true
 ```
 <hr />
+
 ## Why mutable tags in GitHub CI/CD workflows are bad ?
 
 Using mutable references like tag-based or branch-based references in your CI/CD workflows can lead to unexpected changes or potential security vulnerabilities if the referenced action is compromised by malicious actors.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </picture>
 
 
-Prevent supply-chain attacks for your third-party GitHub actions!
+Prevent supply-chain attacks from your third-party GitHub actions!
 
 
 Scharf identifies all third-party CI/CD actions used in your Organization without pinned SHA-commits (Protect your CI/CD workflows from supply-chain attacks) creates a analytics-friendly report (CSV, JSON, Syslog) that can be passed to a SIEM system. In addition, Scharf also provides a quick way to inspect third-party actions by listing available tags and associated commit SHA.

--- a/audit_test.go
+++ b/audit_test.go
@@ -1,0 +1,3 @@
+package main
+
+// TODO: Write unit tests for audit.go

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -252,7 +252,7 @@ func TestSHAResolver_resolve(t *testing.T) {
 			},
 		}
 
-		resolver := SHAResolver{}
+		resolver := NewSHAResolver()
 
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

This PR adds a new feature to auto-fix the SHA commits.

This is an addition to `audit` command.

## Changes
- Add a thrid-party license file
- Precise documentation for commands
- Add caching for resolver (reduces network calls & fastens `autofix` process)