### PR TITLE
feat(23): add --dry-run flag to autofix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
     width="100%"
     media="(prefers-color-scheme: dark)"
     src="https://github.com/cybrota/sharfer/blob/main/logo.png"
-    alt="Scarfer logo (dark)"
+    alt="Scharf logo (dark)"
   />
   <img
     width="100%"
     src="https://github.com/cybrota/sharfer/blob/main/logo.png"
-    alt="Sharfer logo (light)"
+    alt="Scharf logo (light)"
   />
 </picture>
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ scharf autofix
 
 `Note`: This command may modify the file content which should be reviewed and committed to Git.
 
+If you just want to preview (no destructive changes) before fixing, include`--dry-run` flag:
+
+```sh
+scharf autofix --dry-run
+```
+This is a safe way to test fixes before applying changes.
+
+
 ## Getting Started with other commands
 
 Scharf comes with two types of commands to assist hardening of GitHub third-party actions.

--- a/actcache/cache.go
+++ b/actcache/cache.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 Naren Yellavula & Cybrota contributors
+// Apache License, Version 2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+// Package to store memory between multiple CLI executions
+
+package actcache
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// hashEntry is the JSON shape for each action in cache.json.
+type hashEntry struct {
+	SHA       string `json:"sha"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+func NewHashEntry() *hashEntry {
+	return &hashEntry{}
+}
+
+// loadCache loads cache.json into a map[action]hashEntry.
+// If the file does not exist, it returns an empty map.
+func loadCache(dir string) (map[string]hashEntry, error) {
+	file := filepath.Join(dir, "cache.json")
+	data, err := os.ReadFile(file)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]hashEntry), nil
+		}
+		return nil, fmt.Errorf("reading %s: %w", file, err)
+	}
+
+	m := make(map[string]hashEntry)
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", file, err)
+	}
+	return m, nil
+}
+
+// saveCache writes the given map[action]hashEntry back to cache.json (with indentation).
+func saveCache(dir string, m map[string]hashEntry) error {
+	buf, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding JSON: %w", err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("ensuring dir %s: %w", dir, err)
+	}
+	file := filepath.Join(dir, "cache.json")
+	if err := os.WriteFile(file, buf, 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", file, err)
+	}
+	return nil
+}
+
+// GetCache returns the entire cache as a map[action]hashEntry.
+func GetCache(dir string) (map[string]hashEntry, error) {
+	return loadCache(dir)
+}
+
+// UpdateCacheEntry sets m[action] = { newSHA, now } and persists it.
+func UpdateCacheEntry(dir, action, newSHA string) error {
+	m, err := loadCache(dir)
+	if err != nil {
+		return err
+	}
+	m[action] = hashEntry{
+		SHA:       newSHA,
+		UpdatedAt: time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	return saveCache(dir, m)
+}
+
+// CacheExists returns true if cache.json exists in dir.
+func CacheExists(dir string) bool {
+	file := filepath.Join(dir, "cache.json")
+	info, err := os.Stat(file)
+	if err == nil {
+		return !info.IsDir()
+	}
+	if os.IsNotExist(err) {
+		return false
+	}
+	return false
+}

--- a/main.go
+++ b/main.go
@@ -141,13 +141,22 @@ func main() {
 		Long:  fmt.Sprintf("%s\n%s", asciiLogo, `🪄 Auto-fixes vulnerable third-party GitHub actions with mutable references. Must run from a Git repository`),
 		Args:  cobra.MinimumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
-			err := sc.AutoFixRepository(regex)
+			isDryRun := cmd.Flag("dry-run")
+			var isDR bool
+			if isDryRun.Value.String() == "true" {
+				isDR = true
+			} else {
+				isDR = false
+			}
+
+			err := sc.AutoFixRepository(regex, isDR)
 			if err != nil {
 				fmt.Println("Not a git repository. Skipping autofix!")
 				return
 			}
 		},
 	}
+	cmdAutoFix.PersistentFlags().Bool("dry-run", false, "Preview the fixes before actually making the changes")
 
 	var cmdFind = &cobra.Command{
 		Use:   "find",

--- a/scanner/audit.go
+++ b/scanner/audit.go
@@ -79,9 +79,13 @@ func AuditRepository(regex *regexp.Regexp) (*Inventory, error) {
 
 // AutoFixRepository tries to match and replace third-party action references with SHA
 // It uses SHA resolution to find accurate SHA
-func AutoFixRepository(regex *regexp.Regexp) error {
+func AutoFixRepository(regex *regexp.Regexp, isDryRun bool) error {
 	// Keep a cache for action SHA to avoid many network lookups
 	resolver := network.NewSHAResolver()
+
+	if isDryRun {
+		fmt.Println("Running autofix in dryrun mode.")
+	}
 
 	if !git.IsGitRepo(".") {
 		return fmt.Errorf("The current directory is not a Git repository")
@@ -135,10 +139,14 @@ func AutoFixRepository(regex *regexp.Regexp) error {
 				}
 			}
 
-			// Write back to workflow file with replaced SHA
-			err := os.WriteFile(fPath, []byte(contentStr), os.ModeAppend)
-			if err != nil {
-				logger.Error("Problem while fixing the action file", "file", fileName, "problem", err.Error())
+			if !isDryRun {
+				// Write back to workflow file with replaced SHA
+				err = os.WriteFile(fPath, []byte(contentStr), os.ModeAppend)
+				if err != nil {
+					logger.Error("Problem while fixing the action file", "file", fileName, "problem", err.Error())
+				}
+			} else {
+				fmt.Println("The displayed fixes are not staged. Re-run the 'scharf autofix' and omit the flag '--dry-run' to apply fixes.")
 			}
 		}
 	}

--- a/scanner/audit.go
+++ b/scanner/audit.go
@@ -115,7 +115,9 @@ func AutoFixRepository(regex *regexp.Regexp, isDryRun bool) error {
 		}
 
 		contentStr := string(fContent)
-		fMatches := regex.FindAllStringSubmatch(contentStr, 4)
+
+		// -1: Match all
+		fMatches := regex.FindAllStringSubmatch(contentStr, -1)
 
 		if len(fMatches) > 0 {
 			fmt.Printf("🪄 Fixing %s: \n", fileName)


### PR DESCRIPTION
## Description

This PR adds a `--dry-run` flag to `autofix` command. This is to provide a preview of changes before actually making them. It also improves performance by using disk-caching.

## Changes

- Fix a bug in `audit` command. Not matching all findings (only 4)
- To improve performance of `autofix` and `lookup` commands, introduced action caching to disk.