### PR TITLE
BUG/38: fix a bug that adds N/A into actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
   <source
     width="100%"
     media="(prefers-color-scheme: dark)"
-    src="https://github.com/cybrota/sharfer/blob/main/logo.png"
+    src="https://raw.githubusercontent.com/cybrota/scharf/refs/heads/main/logo.png"
     alt="Scharf logo (dark)"
   />
   <img
     width="100%"
-    src="https://github.com/cybrota/sharfer/blob/main/logo.png"
+    src="https://raw.githubusercontent.com/cybrota/scharf/refs/heads/main/logo.png"
     alt="Scharf logo (light)"
   />
 </picture>
@@ -73,8 +73,10 @@ This script installs the latest version automatically (requires curl).
 
 Point to a Git repository, run:
 ```sh
-scharf autofix <repo>
+# Auto fix a local repository
+scharf autofix git_repo
 ```
+
 Note: By default audit looks for current directory (.) if repo is not passed.
 
 Scharf rewrites your workflow file, replacing, for example:
@@ -83,13 +85,17 @@ actions/github-script@v7 ➔ actions/github-script@60a0d83039c74a4aee543508d2ffc
 ```
 Include --dry-run to preview changes without modifying files:
 ```sh
-scharf autofix <repo> --dry-run
+scharf autofix git_repo --dry-run
 ```
 
 ### 2. Audit a Single Repository
 Scan for mutable references in your current repository:
 ```sh
-scharf audit <repo>
+# Audit a local repository
+scharf audit git_repo
+
+# Audit a remote repository. This automatically clones remote to /tmp location with scharf-* prefix
+scharf audit https_or_git_url
 ```
 
 The output lists each insecure tag, its file location, and the SHA you should pin. You can pass `--raise-error` flag to return a Non-zero error code.
@@ -141,6 +147,9 @@ jobs:
 ## The Risk of Mutable Tags
 
 Mutable tags (e.g., @v1 or @main) allow action authors to push new code without changing your workflow. If a tag gets compromised, your CI can run malicious code. Scharf eliminates this vulnerability by always pinning to a specific, audited commit.
+
+## TODO for Scharf
+Check Issues Tab on GitHub
 
 ## Further Reading:
 

--- a/main.go
+++ b/main.go
@@ -76,8 +76,8 @@ func main() {
 
 	var cmdAudit = &cobra.Command{
 		Use:   "audit",
-		Short: "🥽 Audit a given Git repository to identify vulnerable actions with mutable references. Must run from a Git repository",
-		Long:  fmt.Sprintf("%s\n%s", asciiLogo, `🥽 Audit the actions and raise error if any mutable references found. Good used with Ci/CD pipelines.`),
+		Short: "🥽 Audit a local or remote Git repository to identify vulnerable actions with mutable references: 'scharf audit <repo>|<url>'",
+		Long:  fmt.Sprintf("%s\n%s", asciiLogo, `🥽 Audit the actions and raise error if any mutable references found. Good used with Ci/CD pipelines: 'scharf audit <repo>|<url>'`),
 		Args:  cobra.MinimumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			then := time.Now()
@@ -111,8 +111,8 @@ func main() {
 
 	var cmdAutoFix = &cobra.Command{
 		Use:   "autofix",
-		Short: "🪄 Auto-fixes vulnerable third-party GitHub actions with mutable references. Must run from a Git repository",
-		Long:  fmt.Sprintf("%s\n%s", asciiLogo, `🪄 Auto-fixes vulnerable third-party GitHub actions with mutable references. Must run from a Git repository`),
+		Short: "🪄 Auto-fixes vulnerable third-party GitHub actions with mutable references: 'scharf autofix <repo>|<url>'",
+		Long:  fmt.Sprintf("%s\n%s", asciiLogo, `🪄 Auto-fixes vulnerable third-party GitHub actions with mutable references: 'scharf audit <repo>|<url>'`),
 		Args:  cobra.MinimumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			isDryRun := cmd.Flag("dry-run")


### PR DESCRIPTION
## Description

This PR fixes a bug in auto fix which adds `N/A` to unfixable actions.

## Changes

- Fix auto fix bug for actions with no version SHA
- Improve Git clone logic by using native client for cloning(Fast) & Fallback to Go-git (slow)
- Update Documentation
- Fix image links in README