### PR TITLE
fix: improve the audit message of pinned to

### DIFF
--- a/scanner/format.go
+++ b/scanner/format.go
@@ -51,25 +51,25 @@ func FormatAuditReport(workflows []Workflow) string {
 
 	for _, wf := range workflows {
 		// Header per workflow
-		b.WriteString(fmt.Sprintf(
+		fmt.Fprintf(&b,
 			"%s%s%s\n",
 			Cyan, wf.FilePath, Reset,
-		))
+		)
 
 		for _, f := range wf.Issues {
 			// Issue line: location + message
 			loc := fmt.Sprintf("Line %d, Col %d", f.Line, f.Column)
-			b.WriteString(fmt.Sprintf(
+			fmt.Fprintf(&b,
 				"  - [%s%s%s] %s%s%s\n",
 				Gray, loc, Reset,
 				Red, f.Description, Reset,
-			))
+			)
 			// Fix line
-			b.WriteString(fmt.Sprintf(
+			fmt.Fprintf(&b,
 				"    🡆 %sFix:%s %s%s%s\n\n",
 				Green, Reset,
 				Yellow, f.FixMsg, Reset,
-			))
+			)
 		}
 	}
 
@@ -129,7 +129,7 @@ func ApplyFixesInFile(wf Workflow, isDryRun bool) error {
 		// Perform exactly one replacement
 		newSuffix := strings.Replace(suffix, issue.Original, fmt.Sprintf("%s@%s # %s", issue.Action, issue.FixSHA, issue.Version), 1)
 		lines[idx] = prefix + newSuffix
-		fmt.Printf("  - [%s%s%s] %s Fixed: Pinned '%s%s' to '%s' %s\n", Gray, loc, Reset, Green, issue.Action, fmt.Sprintf("%s@%s", issue.Action, issue.FixSHA), issue.Version, Reset)
+		fmt.Printf("  - [%s%s%s] %s Fixed: Pinned '%s%s' to '%s' %s\n", Gray, loc, Reset, Green, issue.Action, fmt.Sprintf("@%s", issue.Version), issue.FixSHA, Reset)
 	}
 
 	// 4) Write back (you could write to a temp file + rename for safety)


### PR DESCRIPTION
## Description

This PR improves formatting logic by making it more accurate.

Previous:
- [Line 21, Col 15]  Fixed: Pinned 'actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8' to 'v6' (Confusing)

Current:
- [Line 21, Col 15]  Fixed: Pinned 'actions/checkout@v6' to '8e8c483db84b4bee98b60c0593521ed34d9990e8'

## Changes
- Use `fmt.Fprintf` instead of builder.WriteString