### PR TITLE
fix: remove rootCmd.SetVersionTemplate(...) to reduce binary size

### DIFF
--- a/main.go
+++ b/main.go
@@ -406,7 +406,7 @@ func newRootCmd() *cobra.Command {
 			_ = cmd.Help()
 		},
 	}
-	rootCmd.Flags().BoolP("version", "v", false, "Print Scharf version information")
+	rootCmd.Flags().BoolP("version", "V", false, "Print Scharf version information")
 	rootCmd.AddCommand(cmdLookup, cmdFind, cmdList, cmdAudit, cmdAutoFix, cmdUpgrade, cmdUpgradeAllSHA, cmdVersion)
 
 	return rootCmd

--- a/main.go
+++ b/main.go
@@ -394,8 +394,19 @@ func newRootCmd() *cobra.Command {
 		},
 	}
 
-	var rootCmd = &cobra.Command{Use: "scharf", Long: asciiLogo, Version: cliVersion()}
-	rootCmd.SetVersionTemplate("{{.Version}}\n")
+	var rootCmd = &cobra.Command{
+		Use:  "scharf",
+		Long: asciiLogo,
+		Run: func(cmd *cobra.Command, args []string) {
+			showVersion, _ := cmd.Flags().GetBool("version")
+			if showVersion {
+				fmt.Fprintln(cmd.OutOrStdout(), cliVersion())
+				return
+			}
+			_ = cmd.Help()
+		},
+	}
+	rootCmd.Flags().BoolP("version", "v", false, "Print Scharf version information")
 	rootCmd.AddCommand(cmdLookup, cmdFind, cmdList, cmdAudit, cmdAutoFix, cmdUpgrade, cmdUpgradeAllSHA, cmdVersion)
 
 	return rootCmd

--- a/main_test.go
+++ b/main_test.go
@@ -40,6 +40,7 @@ func TestUpgradeSHAWithoutFromVersionShowsUsage(t *testing.T) {
 }
 
 func TestVersionInfoExposedOnCLI(t *testing.T) {
+	var expected string
 	for _, args := range [][]string{{"--version"}, {"version"}} {
 		stdout, stderr, err := executeRoot(args...)
 		if err != nil {
@@ -48,6 +49,16 @@ func TestVersionInfoExposedOnCLI(t *testing.T) {
 
 		if !strings.Contains(stdout, "commit") || !strings.Contains(stdout, "built") {
 			t.Fatalf("stdout = %q; want version details including commit and build metadata", stdout)
+		}
+		if !strings.HasPrefix(stdout, "version: ") {
+			t.Fatalf("stdout = %q; want direct version output without Cobra prefix", stdout)
+		}
+		if expected == "" {
+			expected = stdout
+			continue
+		}
+		if stdout != expected {
+			t.Fatalf("stdout for %v = %q; want %q", args, stdout, expected)
 		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -41,7 +41,7 @@ func TestUpgradeSHAWithoutFromVersionShowsUsage(t *testing.T) {
 
 func TestVersionInfoExposedOnCLI(t *testing.T) {
 	var expected string
-	for _, args := range [][]string{{"--version"}, {"version"}} {
+	for _, args := range [][]string{{"--version"}, {"version"}, {"-V"}} {
 		stdout, stderr, err := executeRoot(args...)
 		if err != nil {
 			t.Fatalf("unexpected error for %v: %v (stderr: %s)", args, err, stderr)


### PR DESCRIPTION
## Description

v1.4.0 introduced a binary inflation problem (~1.5 MB bump per binary).

The fix is to remove `rootCmd.SetVersionTemplate(...)`  Cobra template entirely and implement custom arg handling.
